### PR TITLE
Avoid diffing if strings are the same

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,6 +21,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,6 +109,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +142,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c137568cc60b904a7724001b35ce2630fd00d5d84805fbb608ab89509d788f"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346de753af073cc87b52b2083a506b38ac176a44cfb05497b622e27be899b369"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213030a2b5a4e0c0892b6652260cf6ccac84827b83a85a534e178e3906c4cf1b"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,9 +178,21 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "bitflags",
+ "clap_lex 0.2.4",
+ "indexmap",
+ "textwrap 0.16.0",
 ]
 
 [[package]]
@@ -152,7 +203,7 @@ checksum = "f13b9c79b5d1dd500d20ef541215a6423c75829ef43117e1b4d17fd8af0b5d76"
 dependencies = [
  "bitflags",
  "clap_derive",
- "clap_lex",
+ "clap_lex 0.3.1",
  "is-terminal",
  "once_cell",
  "strsim 0.10.0",
@@ -170,6 +221,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -213,6 +273,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.23",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
 ]
 
 [[package]]
@@ -352,6 +448,7 @@ dependencies = [
  "chrono",
  "clap 4.1.4",
  "convert_case",
+ "criterion",
  "itertools",
  "openssl",
  "postgres",
@@ -569,6 +666,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +741,16 @@ checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
 dependencies = [
  "cxx",
  "cxx-build",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -804,6 +923,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "openssl"
 version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +1046,34 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+
+[[package]]
+name = "plotters"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b639e642295546c50fcd545198c9d64ee2a38620a628724a3b266d5fbf97"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "postgres"
@@ -1180,6 +1333,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1358,20 @@ name = "serde"
 version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.152"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -1349,6 +1525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,6 +1559,16 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1538,6 +1730,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "wasi"
 version = "0.10.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,6 +1804,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ dependencies = [
 
 [[package]]
 name = "db-compare"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ansi_term",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db-compare"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,9 @@ yaml-rust = "0.4.5"
 
 [dev-dependencies]
 convert_case = "0.6.0"
+criterion = "0.4.0"
 pretty_assertions = "1.3.0"
+
+[[bench]]
+name = "diff_tool"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ pretty_assertions = "1.3.0"
 [[bench]]
 name = "diff_tool"
 harness = false
+
+[[bench]]
+name = "btree_or_vec"
+harness = false

--- a/benches/btree_or_vec.rs
+++ b/benches/btree_or_vec.rs
@@ -1,0 +1,60 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::collections::BTreeMap;
+
+fn insert_remove_btree(list: &[u32]) {
+    let mut btree: BTreeMap<u32, u32> = BTreeMap::new();
+    for i in list {
+        btree.insert(*i, *i);
+    }
+    for i in list {
+        btree.remove(i);
+    }
+}
+fn insert_get_btree(list: &[u32]) {
+    let mut btree: BTreeMap<u32, u32> = BTreeMap::new();
+    for i in list {
+        btree.insert(*i, *i);
+    }
+    for i in list {
+        btree.get(i);
+    }
+}
+
+fn remove_vec(list: &[u32]) {
+    let mut vec: Vec<u32> = Vec::new();
+    for i in list {
+        vec.push(*i);
+    }
+    for i in list {
+        vec.contains(i);
+    }
+    for i in list {
+        vec.retain(|x| x != i);
+    }
+}
+fn only_contain_vec(list: &[u32]) {
+    let mut vec: Vec<u32> = Vec::new();
+    for i in list {
+        vec.push(*i);
+    }
+    for i in list {
+        vec.contains(i);
+    }
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let vec = (0..10000).collect::<Vec<u32>>();
+    c.bench_function("insert_remove_btree", |b| {
+        b.iter(|| insert_remove_btree(black_box(&vec)))
+    });
+    c.bench_function("insert_get_btree", |b| {
+        b.iter(|| insert_get_btree(black_box(&vec)))
+    });
+    c.bench_function("remove_vec", |b| b.iter(|| remove_vec(black_box(&vec))));
+    c.bench_function("only_contain_vec", |b| {
+        b.iter(|| only_contain_vec(black_box(&vec)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/diff_tool.rs
+++ b/benches/diff_tool.rs
@@ -1,0 +1,65 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use similar::{ChangeTag, TextDiff};
+
+fn produce_char_diff(old: &str, new: &str) -> String {
+    use ansi_term::{Colour, Style};
+    use prettydiff::{basic::DiffOp, diff_words};
+
+    let style = Style::new().bold().on(Colour::Black).fg(Colour::Fixed(118));
+    let diff = diff_words(old, new)
+        .set_insert_style(style)
+        .set_insert_whitespace_style(style);
+    if diff.diff().len() == 1 {
+        if let DiffOp::Equal(_) = diff.diff()[0] {
+            return "".to_string();
+        }
+    }
+    format!("> {}", diff)
+}
+fn produce_simple_diff(json1: &str, json2: &str) -> String {
+    let diff = TextDiff::from_lines(json1, json2);
+    let mut output = Vec::new();
+
+    for change in diff.iter_all_changes() {
+        if change.tag() == ChangeTag::Equal {
+            continue;
+        }
+        let sign = match change.tag() {
+            ChangeTag::Delete => "- ",
+            ChangeTag::Insert => "+ ",
+            ChangeTag::Equal => " ",
+        };
+        output.push(format!("{sign}{change}"));
+    }
+    output.join("")
+}
+
+fn simple_compare(a: &str, b: &str) -> bool {
+    a == b
+}
+
+fn criterion_benchmark(c: &mut Criterion) {
+    let old = r#"{"created_at":"2020-05-07T22:52:24","id":41,"name":"John-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I","updated_at":"2020-05-07T22:52:24"}"#;
+    let new = r#"{"created_at":"2020-05-07T22:52:24","id":41,"name":"John-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I-I","updated_at":"2020-05-07T22:52:24"}"#;
+    c.bench_function("char_diff", |b| {
+        b.iter(|| produce_char_diff(black_box(old), black_box(new)))
+    });
+    c.bench_function("simple_diff", |b| {
+        b.iter(|| produce_simple_diff(black_box(old), black_box(new)))
+    });
+    c.bench_function("comparison", |b| {
+        b.iter(|| simple_compare(black_box(old), black_box(new)))
+    });
+    c.bench_function("char_diff eq", |b| {
+        b.iter(|| produce_char_diff(black_box(old), black_box(old)))
+    });
+    c.bench_function("simple_diff eq", |b| {
+        b.iter(|| produce_simple_diff(black_box(old), black_box(old)))
+    });
+    c.bench_function("comparison eq", |b| {
+        b.iter(|| simple_compare(black_box(old), black_box(old)))
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -30,8 +30,6 @@ pub enum Commands {
             help = "Destination folder for diff files, default: `./diffs`"
         )]
         output_folder: Option<String>,
-        #[arg(long = "diff-format", help = "`simple` or `char`, default: `char`")]
-        diff_format: Option<String>,
         #[arg(long = "tables", help = "Comma separated list of tables to check")]
         tables: Option<String>,
         #[arg(

--- a/src/database/request.rs
+++ b/src/database/request.rs
@@ -126,7 +126,6 @@ mod test {
             no_tls: false,
             by_id_sample_size: None,
             output_folder: None,
-            diff_format: None,
             tables: None,
             config: None,
             tm_cutoff: None,

--- a/src/diff/formatter.rs
+++ b/src/diff/formatter.rs
@@ -228,7 +228,7 @@ fn produce_simple_diff(json1: &str, json2: &str) -> Option<String> {
 fn print_diff(result: Option<String>) -> String {
     match result {
         None => "".to_string(),
-        Some(diff) => diff.to_string(),
+        Some(diff) => diff,
     }
 }
 

--- a/src/diff/formatter.rs
+++ b/src/diff/formatter.rs
@@ -170,7 +170,7 @@ fn normalize_input(list: &DBResultType) -> Result<String, serde_json::Error> {
     Ok(list)
 }
 
-fn produce_diff(config: &Config, json1: &str, json2: &str) -> Option<String> {
+fn produce_diff(_config: &Config, json1: &str, json2: &str) -> Option<String> {
     if json1 == json2 {
         return None;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,22 +17,6 @@ pub use jobs::Job;
 const DEFAULT_LIMIT: u32 = 100;
 
 #[derive(Debug, Default)]
-pub enum DiffFormat {
-    Simple,
-    #[default]
-    Char,
-}
-impl DiffFormat {
-    pub fn new(format: &str) -> Self {
-        match format {
-            "simple" => Self::Simple,
-            "char" => Self::Char,
-            _ => panic!("invalid diff format: {}", format),
-        }
-    }
-}
-
-#[derive(Debug, Default)]
 pub struct Config {
     pub db1: String,
     pub db2: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,6 @@ pub struct Config {
     pub tls: bool,
     pub limit: u32,
     pub diff_io: RefCell<diff::IOType>,
-    pub diff_format: DiffFormat,
     pub white_listed_tables: Option<Vec<String>>,
     pub jobs: Vec<Job>,
     pub by_id_sample_size: Option<u32>,
@@ -72,7 +71,6 @@ impl Config {
                 by_id_sample_size: args_by_id_sample_size,
                 no_tls: args_no_tls,
                 output_folder: args_output_folder,
-                diff_format: args_diff_format,
                 tables: args_tables,
                 jobs: args_jobs,
                 tm_cutoff: args_tm_cutoff,
@@ -117,15 +115,6 @@ impl Config {
                     }
                 };
 
-                let diff_format = if let Some(format) = &args_diff_format {
-                    DiffFormat::new(format)
-                } else {
-                    match config_file.diff_format {
-                        Some(format) => DiffFormat::new(&format),
-                        _ => DiffFormat::Char,
-                    }
-                };
-
                 let limit = if *args_limit != DEFAULT_LIMIT {
                     *args_limit
                 } else {
@@ -163,7 +152,6 @@ impl Config {
                     db1,
                     db2,
                     output_folder,
-                    diff_format,
                     white_listed_tables,
                     limit,
                     jobs,
@@ -189,7 +177,6 @@ struct ConfigFile {
     white_listed_tables: Option<Vec<String>>,
     jobs: Option<Vec<Job>>,
     by_id_sample_size: Option<u32>,
-    diff_format: Option<String>,
     output_folder: Option<String>,
 }
 
@@ -229,10 +216,6 @@ impl ConfigFile {
                     yaml_rust::Yaml::BadValue => None,
                     data => data.clone().into_string(),
                 };
-                let diff_format: Option<String> = match &yaml[0]["diff-format"] {
-                    yaml_rust::Yaml::BadValue => None,
-                    data => data.clone().into_string(),
-                };
                 let jobs: Option<Vec<Job>> = match &yaml[0]["jobs"] {
                     yaml_rust::Yaml::BadValue => None,
                     data => Some(
@@ -264,7 +247,6 @@ impl ConfigFile {
                     db2,
                     limit,
                     output_folder,
-                    diff_format,
                     white_listed_tables,
                     jobs,
                     by_id_sample_size,
@@ -290,7 +272,6 @@ mod test {
             limit: 1,
             no_tls: false,
             by_id_sample_size: None,
-            diff_format: None,
             jobs: None,
             config: None,
             tm_cutoff: None,
@@ -311,7 +292,6 @@ mod test {
             db2: Some("postgresql://postgres:postgres@127.0.0.1/db2".to_string()),
             no_tls: false,
             by_id_sample_size: None,
-            diff_format: None,
             jobs: None,
             tables: None,
             tm_cutoff: None,
@@ -335,7 +315,6 @@ mod test {
             db2: Some("postgresql://postgres:postgres@127.0.0.1/db2".to_string()),
             no_tls: false,
             by_id_sample_size: None,
-            diff_format: None,
             jobs: None,
             tm_cutoff: None,
             output_folder: None,

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -8,7 +8,6 @@ fn default_args() -> Commands {
     Commands::Run {
         db1: Some(DB::A.url()),
         db2: Some(DB::B.url()),
-        diff_format: None,
         limit: 1,
         no_tls: false,
         by_id_sample_size: None,


### PR DESCRIPTION
Breaking changes:

- `diff-format` argument not longer supported